### PR TITLE
feat(DumbbellChart): polish sizing, contrast, and interpretation text (#64, #65, #66)

### DIFF
--- a/client/src/components/charts/DumbbellChart.tsx
+++ b/client/src/components/charts/DumbbellChart.tsx
@@ -491,8 +491,8 @@ function DumbbellChartInner({ metrics, height = 700 }: DumbbellChartProps) {
       };
     }
     return {
-      homeKnob: lighten(teamColor, 0.1),
-      awayKnob: darken(teamColor, 0.2),
+      homeKnob: lighten(teamColor, 0.3),
+      awayKnob: darken(teamColor, 0.4),
       fillColor: teamColor,
     };
   };


### PR DESCRIPTION
## Sprint: Dumbbell Chart Polish

Closes #64, #65, #66

### Issue #64 — Sizing Consistency
- Reduced `rowHeight` from 38 → 28, `knobRadius` from 10 → 7, `trackHeight` from 7 → 5
- Reduced `marginLeft` 160 → 135, `marginRight` 70 → 60, `marginTop` 40 → 30
- Reduced team name font 11.5px → 10px, tick font 9.5px → 8.5px, gap label font 11px → 9.5px
- Team color dot radius 4.5 → 3.5
- **Net SVG height drops from ~1200px to ~880px**, now proportional to adjacent Travel tab charts

### Issue #65 — Visual Contrast & Neumorphic Depth
- **65a (Toggle Contrast):** Active toggles now get a cyan-tinted background and deeper inset `boxShadow` overrides (both dark and light mode)
- **65b (Light Mode Fill):** Darkened the fill color between knobs in light mode (`#5aacbc` → `#1a7a8a`) for richer visibility
- **65c (Grooved Track Inset):** Swapped `feOffset` directions in the SVG filter so the groove reads as a recessed channel instead of a raised bump; inverted the vertical gradient stops for correct concave lighting

### Issue #66 — Interpretation Text & Metric Explanations
- **66a (Description Enhancement):** Enriched the ChartHeader description with expected-pattern guidance and outlier-spotting cues
- **66b (Dynamic Metric Context):** Added a contextual paragraph below the description that updates when toggling PPG / WIN% / GD (FiveThirtyEight editorial style)
- **66c (Sort Order Indicator):** Added a subtle label: *"Sorted by gap magnitude (largest first)"*

### Testing
- [x] Build passes (`vite build` clean)
- [x] All 30 rows legible at new row height
- [x] Single file changed: `DumbbellChart.tsx` (70 insertions, 18 deletions)