### PR TITLE
feat: InsightPanel UI Redesign — Mechanical Door Animation

### DIFF
--- a/client/src/components/CardInsight.tsx
+++ b/client/src/components/CardInsight.tsx
@@ -4,10 +4,10 @@
  * When the user clicks the lightbulb button in a card header, a new
  * NeuInsightContainer appears INSIDE the card body (below the header,
  * above the chart/content), pushing the content down. The container
- * uses the same depression-to-elevation animation as the tab-wide
- * ANALYZE panel, creating a consistent "insight rises above data" metaphor.
+ * uses the same mechanical-door animation as the tab-wide ANALYZE panel,
+ * scaled down for the compact variant.
  *
- * The CardInsightToggle now renders as an IconAction (Lightbulb, amber active)
+ * The CardInsightToggle renders as an IconAction (Lightbulb, amber active)
  * for consistent Three-Zone architecture integration.
  */
 
@@ -94,7 +94,6 @@ export function CardInsightSection({
         isOpen={isOpen}
         isDark={isDark}
         variant="compact"
-        showDepression={isOpen}
       >
         <AnimatePresence mode="wait">
           {isOpen && (

--- a/client/src/components/InsightPanel.tsx
+++ b/client/src/components/InsightPanel.tsx
@@ -3,13 +3,15 @@
  *
  * Layout:
  *   [ANALYZE button]                    ← always visible, outside the container
- *   [NeuInsightContainer]               ← depression groove when closed, elevated with cards when open
+ *   [NeuInsightContainer]               ← mechanical-door reveal when opened, invisible when closed
  *     └── Header line                   ← describes what the panel shows
  *     └── 2x2 grid of InsightCards      ← tactile 3D cards with embossed borders
  *
- * The container always renders (showing the depression floor when collapsed).
- * When the user clicks ANALYZE, the container rises above surrounding content
- * with deeper shadows than standard NeuCards, and the insight cards animate in.
+ * The container renders nothing when collapsed — no depression groove.
+ * When the user clicks ANALYZE, a cinematic mechanical-door sequence plays:
+ *   Stage 1: Dark bay cavity appears, doors part horizontally
+ *   Stage 2: Elevated container rises out of the cavity
+ *   Stage 3: Content blooms in with staggered fade
  */
 
 import { useState } from "react";
@@ -118,12 +120,11 @@ export function InsightPanel({
         {isOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
       </button>
 
-      {/* NeuInsightContainer — shows depression groove when closed, rises when open */}
+      {/* NeuInsightContainer — mechanical door reveal when opened, invisible when closed */}
       <NeuInsightContainer
         isOpen={isOpen}
         isDark={isDark}
         variant="full"
-        showDepression={true}
       >
         <AnimatePresence mode="wait">
           {isOpen && (
@@ -264,7 +265,7 @@ function InsightCard({
       initial={{ opacity: 0, y: 14, scale: 0.96 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={{
-        delay: index * 0.08 + 0.12,
+        delay: index * 0.08 + 0.08,
         duration: 0.35,
         ease: [0.4, 0, 0.2, 1],
       }}

--- a/client/src/components/NeuInsightContainer.tsx
+++ b/client/src/components/NeuInsightContainer.tsx
@@ -1,22 +1,34 @@
 /**
- * NeuInsightContainer — Neumorphic container that transitions between
- * a sunken depression and a dramatically elevated state.
+ * NeuInsightContainer — Cinematic "Mechanical Door" Animation
  *
- * When inactive: a subtle recessed groove in the surface (inset shadows).
- *   Renders as a thin bar (~14px for full, ~8px for compact).
- * When active: rises prominently above surrounding content with deep,
- *   long-casting shadows that spill onto the environment beneath it.
- *   No cyan border glow — the glow effect is on the sparkle icon in
- *   the InsightPanel header instead.
+ * Replaces the old depression-groove approach with a three-stage
+ * Iron-Man-style reveal sequence:
  *
- * Shadow depth comparison:
+ *   Stage 1 — The Parting Doors (0–300ms)
+ *     A dark recessed cavity appears. Pseudo-door panels scale inward
+ *     on the X-axis (scaleX 1→0), revealing the bay underneath.
+ *
+ *   Stage 2 — The Ascent (300–600ms)
+ *     The elevated insight container rises out of the cavity
+ *     (translateY +40 → −6), masked by the bay's overflow-hidden.
+ *
+ *   Stage 3 — Content Bloom (500–800ms)
+ *     Internal children fade in and scale 0.95→1, handled by the
+ *     parent (InsightPanel / CardInsightSection) via stagger delays.
+ *
+ * When collapsed the component renders **nothing** — no depression,
+ * no groove, no residual artifact.
+ *
+ * Shadow depth comparison (unchanged):
  *   neu-flat:    6px/6px/12px   (base level)
  *   neu-raised:  8px/8px/16px   (standard cards)
  *   THIS active: 18px/18px/40px + translateY(-6px)
  */
 
 import { ReactNode, useRef, useState, useEffect } from "react";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
+
+/* ── Props ─────────────────────────────────────────────────── */
 
 interface NeuInsightContainerProps {
   isOpen: boolean;
@@ -24,8 +36,11 @@ interface NeuInsightContainerProps {
   children: ReactNode;
   variant?: "full" | "compact";
   className?: string;
+  /** @deprecated — no longer used; kept for API compat */
   showDepression?: boolean;
 }
+
+/* ── Component ─────────────────────────────────────────────── */
 
 export function NeuInsightContainer({
   isOpen,
@@ -33,7 +48,6 @@ export function NeuInsightContainer({
   children,
   variant = "full",
   className = "",
-  showDepression = true,
 }: NeuInsightContainerProps) {
   const isCompact = variant === "compact";
   const contentRef = useRef<HTMLDivElement>(null);
@@ -51,128 +65,211 @@ export function NeuInsightContainer({
     }
   }, [isOpen, children]);
 
-  // Depression height (the thin groove when collapsed)
-  const depressionHeight = isCompact ? 8 : 14;
-
-  // ── Shadow definitions — deep neumorphic elevation, NO cyan glow ──
+  /* ── Shadow definitions — deep neumorphic elevation ────── */
   const activeShadow = isDark
     ? [
-        // Primary deep shadow — long cast below
         "0 18px 40px rgba(0,0,0,0.7)",
         "0 8px 16px rgba(0,0,0,0.5)",
-        // Lift shadow — subtle upper-left highlight
         "-6px -6px 16px rgba(60,60,80,0.12)",
-        // Inner top highlight — surface light catch
         "inset 0 1px 0 rgba(255,255,255,0.08)",
         "inset 0 -1px 0 rgba(0,0,0,0.3)",
       ].join(", ")
     : [
-        // Primary deep shadow — long cast below
         "0 18px 40px rgba(140,145,170,0.4)",
         "0 8px 16px rgba(166,170,190,0.35)",
-        // Lift shadow — bright upper-left
         "-6px -6px 16px rgba(255,255,255,0.95)",
-        // Inner top highlight — glossy surface
         "inset 0 1px 0 rgba(255,255,255,0.85)",
         "inset 0 -1px 0 rgba(166,170,190,0.12)",
       ].join(", ");
 
-  const depressionShadow = isDark
-    ? "inset 3px 3px 8px rgba(0,0,0,0.5), inset -3px -3px 8px rgba(60,60,80,0.08)"
-    : "inset 3px 3px 8px rgba(166,170,190,0.35), inset -3px -3px 8px rgba(255,255,255,0.6)";
-
-  // ── Colors ──
+  /* ── Colors ─────────────────────────────────────────────── */
   const activeBg = isDark ? "#232340" : "#ebedf6";
-  const depressionBg = isDark ? "#141422" : "#d8d8e2";
+  const bayBg = isDark ? "#141422" : "#d0d0dc";
 
-  // Neutral border — no cyan accent
   const activeBorder = isDark
     ? "1.5px solid rgba(255,255,255,0.06)"
     : "1.5px solid rgba(0,0,0,0.06)";
-  const depressionBorder = isDark
-    ? "1px solid rgba(255,255,255,0.02)"
-    : "1px solid rgba(0,0,0,0.03)";
 
   const rounding = isCompact ? "rounded-lg" : "rounded-2xl";
   const padding = isCompact ? 10 : 20;
 
-  // Don't render if not open and depression is disabled
-  if (!isOpen && !showDepression) return null;
+  /* ── Bay inner shadow — deep mechanical recess look ───── */
+  const bayInnerShadow = isDark
+    ? "inset 0 4px 16px rgba(0,0,0,0.6), inset 0 1px 4px rgba(0,0,0,0.4)"
+    : "inset 0 4px 16px rgba(0,0,0,0.1), inset 0 1px 4px rgba(0,0,0,0.06)";
 
+  /* ── Timing constants ──────────────────────────────────── */
+  const doorDuration = isCompact ? 0.2 : 0.3;
+  const riseDuration = isCompact ? 0.25 : 0.35;
+  const riseDelay = isCompact ? 0.12 : 0.2;
+  const riseY = isCompact ? -2 : -6;
+
+  /* ── Render nothing when collapsed ─────────────────────── */
   return (
-    <>
-      <motion.div
-        animate={{
-          height: isOpen ? contentHeight + padding * 2 : depressionHeight,
-          boxShadow: isOpen ? activeShadow : depressionShadow,
-          background: isOpen ? activeBg : depressionBg,
-          y: isOpen ? (isCompact ? -2 : -6) : 0,
-          marginTop: isOpen ? (isCompact ? 4 : 8) : 0,
-          marginBottom: isOpen ? (isCompact ? 4 : 16) : 0,
-        }}
-        transition={{
-          duration: 0.45,
-          ease: [0.22, 1, 0.36, 1],
-        }}
-        className={`${rounding} overflow-hidden ${className}`}
-        style={{
-          position: "relative",
-          zIndex: isOpen ? 10 : 1,
-          border: isOpen ? activeBorder : depressionBorder,
-        }}
-      >
-        {/* Bottom edge shadow line — reinforces the floating effect */}
-        {isOpen && !isCompact && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.2, duration: 0.3 }}
-            className="absolute inset-x-0 bottom-0 h-[1px] pointer-events-none"
-            style={{
-              background: isDark
-                ? "linear-gradient(90deg, transparent 10%, rgba(0,0,0,0.4) 50%, transparent 90%)"
-                : "linear-gradient(90deg, transparent 10%, rgba(0,0,0,0.08) 50%, transparent 90%)",
-            }}
-          />
-        )}
-
-        {/* Content */}
+    <AnimatePresence mode="wait">
+      {isOpen && (
         <motion.div
-          ref={contentRef}
+          key="bay-wrapper"
+          /* Stage 1 — Bay Wrapper: the cavity that parts open */
+          initial={{
+            height: 0,
+            opacity: 0,
+            marginTop: 0,
+            marginBottom: 0,
+          }}
           animate={{
-            opacity: isOpen ? 1 : 0,
-            padding: isOpen ? padding : 0,
+            height: contentHeight + padding * 2 + 16, // extra room for float
+            opacity: 1,
+            marginTop: isCompact ? 4 : 8,
+            marginBottom: isCompact ? 4 : 16,
+          }}
+          exit={{
+            height: 0,
+            opacity: 0,
+            marginTop: 0,
+            marginBottom: 0,
           }}
           transition={{
-            opacity: {
-              duration: isOpen ? 0.3 : 0.15,
-              delay: isOpen ? 0.15 : 0,
+            height: {
+              type: "spring",
+              stiffness: isCompact ? 350 : 300,
+              damping: isCompact ? 35 : 30,
             },
-            padding: { duration: 0.3 },
+            opacity: { duration: 0.15 },
+            marginTop: { duration: doorDuration },
+            marginBottom: { duration: doorDuration },
+          }}
+          className={`${rounding} overflow-hidden relative ${className}`}
+          style={{
+            background: bayBg,
+            boxShadow: bayInnerShadow,
+            zIndex: 10,
           }}
         >
-          {children}
-        </motion.div>
-      </motion.div>
+          {/* ── Door panels — scale X from 1→0 to reveal the bay ── */}
+          {/* Left door */}
+          <motion.div
+            initial={{ scaleX: 1 }}
+            animate={{ scaleX: 0 }}
+            exit={{ scaleX: 1 }}
+            transition={{
+              duration: doorDuration,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+            className="absolute inset-0 z-20 pointer-events-none"
+            style={{
+              transformOrigin: "left center",
+              background: isDark
+                ? "linear-gradient(90deg, #1a1a2e 0%, #141422 100%)"
+                : "linear-gradient(90deg, #dcdce6 0%, #d0d0dc 100%)",
+              borderRight: isDark
+                ? "1px solid rgba(255,255,255,0.04)"
+                : "1px solid rgba(0,0,0,0.04)",
+            }}
+          />
+          {/* Right door */}
+          <motion.div
+            initial={{ scaleX: 1 }}
+            animate={{ scaleX: 0 }}
+            exit={{ scaleX: 1 }}
+            transition={{
+              duration: doorDuration,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+            className="absolute inset-0 z-20 pointer-events-none"
+            style={{
+              transformOrigin: "right center",
+              background: isDark
+                ? "linear-gradient(270deg, #1a1a2e 0%, #141422 100%)"
+                : "linear-gradient(270deg, #dcdce6 0%, #d0d0dc 100%)",
+              borderLeft: isDark
+                ? "1px solid rgba(255,255,255,0.04)"
+                : "1px solid rgba(0,0,0,0.04)",
+            }}
+          />
 
-      {/* Cast shadow element — sits below the container to cast onto content beneath */}
-      {isOpen && !isCompact && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ delay: 0.2, duration: 0.4 }}
-          className="pointer-events-none"
-          style={{
-            height: 8,
-            marginTop: -4,
-            background: isDark
-              ? "radial-gradient(ellipse 80% 100% at 50% 0%, rgba(0,0,0,0.15) 0%, transparent 100%)"
-              : "radial-gradient(ellipse 80% 100% at 50% 0%, rgba(140,145,170,0.1) 0%, transparent 100%)",
-          }}
-        />
+          {/* ── Center seam line — the split where doors part ── */}
+          <motion.div
+            initial={{ opacity: 0.8, scaleY: 1 }}
+            animate={{ opacity: 0, scaleY: 0.5 }}
+            exit={{ opacity: 0.8, scaleY: 1 }}
+            transition={{ duration: doorDuration * 0.6 }}
+            className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-[1px] z-30 pointer-events-none"
+            style={{
+              background: isDark
+                ? "rgba(0,212,255,0.25)"
+                : "rgba(8,145,178,0.2)",
+              boxShadow: isDark
+                ? "0 0 8px rgba(0,212,255,0.3)"
+                : "0 0 8px rgba(8,145,178,0.2)",
+            }}
+          />
+
+          {/* ── Stage 2 — Rising container ── */}
+          <motion.div
+            initial={{ y: 40, opacity: 0 }}
+            animate={{ y: riseY, opacity: 1 }}
+            exit={{ y: 40, opacity: 0 }}
+            transition={{
+              y: {
+                type: "spring",
+                stiffness: isCompact ? 350 : 280,
+                damping: isCompact ? 30 : 26,
+                delay: riseDelay,
+              },
+              opacity: {
+                duration: 0.2,
+                delay: riseDelay,
+              },
+            }}
+            className={`${rounding} relative z-10`}
+            style={{
+              background: activeBg,
+              boxShadow: activeShadow,
+              border: activeBorder,
+              margin: isCompact ? 4 : 8,
+            }}
+          >
+            {/* Bottom edge shadow line — reinforces floating effect */}
+            {!isCompact && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: riseDelay + 0.15, duration: 0.3 }}
+                className="absolute inset-x-0 bottom-0 h-[1px] pointer-events-none"
+                style={{
+                  background: isDark
+                    ? "linear-gradient(90deg, transparent 10%, rgba(0,0,0,0.4) 50%, transparent 90%)"
+                    : "linear-gradient(90deg, transparent 10%, rgba(0,0,0,0.08) 50%, transparent 90%)",
+                }}
+              />
+            )}
+
+            {/* Content wrapper */}
+            <motion.div
+              ref={contentRef}
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{
+                opacity: {
+                  duration: 0.25,
+                  delay: riseDelay + 0.1,
+                },
+                scale: {
+                  duration: 0.25,
+                  delay: riseDelay + 0.1,
+                  ease: [0.22, 1, 0.36, 1],
+                },
+              }}
+              style={{ padding }}
+            >
+              {children}
+            </motion.div>
+          </motion.div>
+        </motion.div>
       )}
-    </>
+    </AnimatePresence>
   );
 }
 

--- a/client/src/components/charts/TravelScatterChart.tsx
+++ b/client/src/components/charts/TravelScatterChart.tsx
@@ -57,7 +57,6 @@ function TeamInsightSection({
         isOpen={isOpen}
         isDark={isDark}
         variant="compact"
-        showDepression={isOpen}
       >
         <AnimatePresence mode="wait">
           {isOpen && (


### PR DESCRIPTION
## Sprint: InsightPanel UI Redesign (Mechanical Door Animation)

### Problem
The `InsightPanel` component rendered a persistent 14px dark depression groove when collapsed — an unfinished-looking artifact that broke the clean dashboard aesthetic at rest.

### Solution
Replaced the static depression with a cinematic three-stage **mechanical door** animation sequence powered by Framer Motion:

| Stage | Timing | Effect |
|-------|--------|--------|
| **1. Parting Doors** | 0–300ms | Dark bay cavity appears; door panels scale X from 1→0, revealing the mechanical recess. Cyan center seam fades as doors part. |
| **2. The Ascent** | 300–600ms | Elevated container rises from +40px to −6px inside overflow-hidden bay (true emergence masking). Spring physics for mechanical feel. |
| **3. Content Bloom** | 500–800ms | Content fades in with scale 0.95→1. Header appears first, then insight cards stagger in. |

### Files Changed
- **`NeuInsightContainer.tsx`** — Full rewrite with bay wrapper, door panels, rising container, and content bloom
- **`InsightPanel.tsx`** — Removed `showDepression={true}`, updated docs and stagger timing
- **`CardInsight.tsx`** — Removed `showDepression={isOpen}`, updated docs
- **`TravelScatterChart.tsx`** — Removed `showDepression={isOpen}` from custom TeamInsightSection

### Success Criteria
- [x] Persistent dark depression line completely gone when panel is closed
- [x] Clicking ANALYZE triggers horizontal door-opening effect
- [x] Elevated container visibly rises out of the cavity (masked by borders)
- [x] Animation is smooth, hardware-accelerated (transform + opacity only)
- [x] Closing reverses the sequence (container sinks, doors slide shut)
- [x] Compact variant (CardInsight) inherits animation with tighter timing
- [x] Build passes with zero new errors
